### PR TITLE
Tidy up gradle and build config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 group = 'tech.pegasys.pantheon'
 
+defaultTasks 'build', 'checkLicenses', 'javadoc'
+
 repositories {
   if ("$System.env.JENKINS_URL" == 'https://jenkins.pegasys.tech/') {
     maven { url "https://nexus.int.pegasys.tech/repository/consensys-pegasys/" }
@@ -142,9 +144,9 @@ publishing {
           }
         }
         scm {
-          connection = 'scm:git:git://github.com/PegaSysEng/pantheon.git'
-          developerConnection = 'scm:git:ssh://github.com/PegaSysEng/pantheon.git'
-          url = 'https://github.com/PegaSysEng/pantheon'
+          connection = 'scm:git:git://github.com/PegaSysEng/pantheon-plugin-api.git'
+          developerConnection = 'scm:git:ssh://github.com/PegaSysEng/pantheon-plugin-api.git'
+          url = 'https://github.com/PegaSysEng/pantheon-plugin-api'
         }
       }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Extract the Gradle cleanup from #7 to a standalone PR.  Omits the renaming from plugin API to Pantheon API.

Also set default build tasks.