### PR TITLE
Adding containsKey to KeyValueStorage

### DIFF
--- a/src/main/java/tech/pegasys/pantheon/plugin/services/storage/KeyValueStorage.java
+++ b/src/main/java/tech/pegasys/pantheon/plugin/services/storage/KeyValueStorage.java
@@ -34,6 +34,16 @@ public interface KeyValueStorage extends Closeable {
   void clear() throws StorageException;
 
   /**
+   * Whether the key-value storage contains the given key.
+   *
+   * @param key a key that might be contained in the key-value storage.
+   * @return <code>true</code> when the given key is present in keyset, <code>false</code>
+   *     otherwise.
+   * @throws StorageException problem encountered when interacting with the key set.
+   */
+  boolean containsKey(byte[] key) throws StorageException;
+
+  /**
    * Retrieves the value associated with a given key.
    *
    * @param key whose associated value is being retrieved.


### PR DESCRIPTION
While functionally this method can be reproduced by checking that a value is present for any given key (assuming no null values), semantically it does mean something different and reads nicer in Pantheon.
`storage.containsKey(key)` 
vs
`storage.get(key).isPresent()