### PR TITLE
Revert "[PAN-3063] Add method to fetch enclave url"

### DIFF
--- a/src/main/java/tech/pegasys/pantheon/plugin/services/PantheonConfiguration.java
+++ b/src/main/java/tech/pegasys/pantheon/plugin/services/PantheonConfiguration.java
@@ -12,9 +12,7 @@
  */
 package tech.pegasys.pantheon.plugin.services;
 
-import java.net.URI;
 import java.nio.file.Path;
-import java.util.Optional;
 
 /** Generally useful configuration provided by Pantheon. */
 public interface PantheonConfiguration {
@@ -25,12 +23,4 @@ public interface PantheonConfiguration {
    * @return location of the storage in the file system of the client.
    */
   Path getStoragePath();
-
-  /**
-   * Url of the enclave that stores private transaction data.
-   *
-   * @return an optional containing the url of the enclave Pantheon is connected to, or empty if
-   *     privacy is not enabled.
-   */
-  Optional<URI> getEnclaveUrl();
 }


### PR DESCRIPTION
Reverts PegaSysEng/pantheon-plugin-api#25

Will not be necessary for 1.3

Better to revert this for now as we may want to implement it differently in the future.

[PAN-3127] 